### PR TITLE
Dialogflow から Webhook で通知される JSON データの全文が、 GAE でログ出力されないバグを修正 #381

### DIFF
--- a/src/main/java/com/mizo0203/google/home/shiritori/HelloServlet.java
+++ b/src/main/java/com/mizo0203/google/home/shiritori/HelloServlet.java
@@ -2,11 +2,13 @@ package com.mizo0203.google.home.shiritori;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mizo0203.google.home.shiritori.data.Data;
+import org.apache.commons.io.IOUtils;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 public class HelloServlet extends HttpServlet {
@@ -34,7 +36,9 @@ public class HelloServlet extends HttpServlet {
     public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 
         // サーバーが受けたデータ
-        String line = req.getReader().readLine();
-        LOG.info("doPost() line: " + line);
+        // OSS ライブラリ「Apache Commons IO」を導入すると
+        // InputStream 型から String 型へ 1 発変換できる
+        String body = IOUtils.toString(req.getInputStream(), StandardCharsets.UTF_8);
+        LOG.info("doPost() body: " + body);
     }
 }


### PR DESCRIPTION
Dialogflow から Webhook で通知される JSON データの全文が、 GAE でログ出力されないバグを修正 #381

## 現象

* Dialogflow から Webhook で通知される JSON データの全文が、 GAE でログ出力されない

```
com.mizo0203.google.home.shiritori.HelloServlet doPost: doPost() line: { (HelloServlet.java:38) // ★ "{" 以降がログ出力されない
```

## 原因

* POST データ (body) の 1 行目しかログ出力していなかった

## 対処

* POST データ (body) の全文がログ出力されるように修正
