### PR TITLE
AI がランダムな単語を返すようにする

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,13 +77,13 @@ class MainPage(webapp2.RequestHandler):
                     if infra.check_word_datastore(userId, reading):
                         infra.save_word_datastore(userId, reading)
                         logging.info(reading)
-                        # FIXME: 暫定実装
                         word_record = infra.search_word_record_from_dic(
-                            reading[-1])
+                            userId, reading[-1])
                         logging.info(word_record)
                         word = word_record[u'org'][0]
+                        infra.save_word_datastore(userId, word_record[u'key'])
                         fulfillmentText = word + u'、の、' + word_record[u'end']
-                        logging.info(word)
+                        logging.info(fulfillmentText)
                         obj = {
                             u'fulfillmentText': fulfillmentText,
                         }


### PR DESCRIPTION
## AI がランダムな単語を返すようにする

* 辞書にある単語のうち、無効な単語（既出の単語・「ん」で終わる単語）を除いたリストからランダムな単語を返すように変更
* AI が言った単語を不揮発領域に保存する処理を追加
    * 以降のプレイでは、「既出の単語」になるため、ユーザ・ AI 共に使用できない