### PR TITLE
feat(*.py): Add support for last word. fix #416 @3.0h

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 110

--- a/infra.py
+++ b/infra.py
@@ -42,6 +42,25 @@ def reset_datastore(user_id):
         pass
 
 
+def get_last_word_datastore(user_id):
+    try:
+        user = User.get_by_id(user_id)
+        if user.last_word == u'':
+            return u'リ'
+        return user.last_word[-1]
+    except Exception:
+        return u'リ'
+
+
+def check_last_word_datastore(user_id, check_word):
+    try:
+        if check_word[0] == get_last_word_datastore(user_id):
+            return True
+        return False
+    except Exception:
+        return True
+
+
 def check_word_datastore(user_id, check_word):
     try:
         user = User.get_by_id(user_id)

--- a/main.py
+++ b/main.py
@@ -77,28 +77,34 @@ class MainPage(webapp2.RequestHandler):
                 if reading:
                     logging.info(reading)
                     reading_end = reading[-1]
-                    if reading_end == u'ン':
-                        obj = {
-                            u'followupEventInput': {
-                                u'name': DECLARE_USER_LOSE_EVENT,
-                                u'languageCode': queryResult[u'languageCode'],
+                    if infra.check_last_word_datastore(userId, reading):
+                        if reading_end == u'ン':
+                            infra.reset_datastore(userId)
+                            obj = {
+                                u'followupEventInput': {
+                                    u'name': DECLARE_USER_LOSE_EVENT,
+                                    u'languageCode': queryResult[u'languageCode'],
+                                }
                             }
-                        }
-                    elif infra.check_word_datastore(userId, reading):
-                        infra.save_word_datastore(userId, reading)
-                        word_record = infra.search_word_record_from_dic(
-                            userId, reading[-1])
-                        logging.info(word_record)
-                        word = word_record[u'org'][0]
-                        infra.save_word_datastore(userId, word_record[u'key'])
-                        fulfillmentText = word + u'、の、' + word_record[u'end']
-                        logging.info(fulfillmentText)
-                        obj = {
-                            u'fulfillmentText': fulfillmentText,
-                        }
+                        elif infra.check_word_datastore(userId, reading):
+                            infra.save_word_datastore(userId, reading)
+                            word_record = infra.search_word_record_from_dic(
+                                userId, reading_end)
+                            logging.info(word_record)
+                            word = word_record[u'org'][0]
+                            infra.save_word_datastore(userId, word_record[u'key'])
+                            fulfillmentText = word + u'、の、' + word_record[u'end']
+                            logging.info(fulfillmentText)
+                            obj = {
+                                u'fulfillmentText': fulfillmentText,
+                            }
+                        else:
+                            obj = {
+                                u'fulfillmentText': u'それは使用済みの言葉です',
+                            }
                     else:
                         obj = {
-                            u'fulfillmentText': u'それは使用済みの言葉です',
+                            u'fulfillmentText': infra.get_last_word_datastore(userId) + u'で始まる言葉を使ってください',
                         }
                 else:
                     obj = {


### PR DESCRIPTION
* last_wordに繋がる単語しか認識しないようにした
* "ん"で終わった場合に、datastoreを初期化するようにした

暫定対応
* flake8の文字数チェックを110文字にした