### PR TITLE
CircleCI にて古い .deb ファイルがキャッシュされないように修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,9 @@ jobs:
               sudo dpkg -i /home/circleci/apt/archives/*.deb
             fi
       - run:
-          name: install lsb-release and set CLOUD_SDK_REPO
+          name: install lsb-release, rename and set CLOUD_SDK_REPO
           command: |
-            sudo apt -d install lsb-release
+            sudo apt -d install lsb-release rename
             if [[ $(find /var/cache/apt/archives -name "*.deb") == *".deb"* ]];then
               sudo dpkg -i /var/cache/apt/archives/*.deb
               mkdir -p /home/circleci/apt/archives/


### PR DESCRIPTION
## CircleCI にて古い .deb ファイルがキャッシュされないように修正

* 1つのパッケージに対して複数の.debファイルがキャッシュされないように修正しました。
    * ファイル名からバージョン番号を削除し、最新の.debファイルを上書きします。
    * パッケージ名に `_` は使用されないため、 `_` 以降を削除
        * https://www.debian.or.jp/community/devel/debian-policy-ja/policy.ja.html/ch-controlfields.html#s-f-Source

* 修正後の CircleCI ビルド: https://circleci.com/gh/mizo0203/google-home-shiritori/235
    * install cache deb file: 00:23